### PR TITLE
Use a smaller subnet

### DIFF
--- a/deploy-headscale-server.yml
+++ b/deploy-headscale-server.yml
@@ -107,8 +107,8 @@
             # IPv4: https://github.com/tailscale/tailscale/blob/22ebb25e833264f58d7c3f534a8b166894a89536/net/tsaddr/tsaddr.go#L33
             # Any other range is NOT supported, and it will cause unexpected issues.
             ip_prefixes:
-              - fd7a:115c:a1e0::/48
-              - 100.64.0.0/10
+              - fd7a:115c:a1e0::/64
+              - 100.64.0.0/24
 
             # DERP is a relay system that Tailscale uses when a direct
             # connection cannot be established.


### PR DESCRIPTION
This patch changes the subnet used by Headscale from the maximum available network to a small network which should be sufficiently big with a smaller chance to conflict with other networks.