### PR TITLE
Remove internal.haardie.org

### DIFF
--- a/deploy-headscale-server.yml
+++ b/deploy-headscale-server.yml
@@ -266,9 +266,7 @@
               # Split DNS (see https://tailscale.com/kb/1054/dns/),
               # list of search domains and the DNS to query for each one.
               #
-              restricted_nameservers:
-                internal.haardie.org:
-                  - 192.168.1.1
+              # restricted_nameservers:
               #   darp.headscale.net:
               #     - 1.1.1.1
               #     - 8.8.8.8


### PR DESCRIPTION
We don't need this and it will conflict with other networks.